### PR TITLE
remove WORD JOINER characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Here's a complete example:
     $ transcribe \
     >   --url 'https://github.com/plaid/example/blob/v1.2.3/{filename}#L{line}' \
     >   -- examples/fp.js
-    ### <a name="map" href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L3">`map :: (a -⁠> b) -⁠> Array a -⁠> Array b`</a>
+    ### <a name="map" href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L3">`map :: (a -> b) -> Array a -> Array b`</a>
 
     Transforms a list of elements of type `a` into a list of elements
     of type `b` using the provided function of type `a -> b`.
@@ -89,7 +89,7 @@ Here's a complete example:
     ['1', '2', '3', '4', '5']
     ```
 
-    ### <a name="filter" href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L21">`filter :: (a -⁠> Boolean) -⁠> Array a -⁠> Array a`</a>
+    ### <a name="filter" href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L21">`filter :: (a -> Boolean) -> Array a -> Array a`</a>
 
     Returns the list of elements which satisfy the provided predicate.
 

--- a/bin/transcribe
+++ b/bin/transcribe
@@ -66,7 +66,6 @@ const controlWrapping = pipe ([
   map2 (joinWith ('')),
   map (joinWith (' => ')),
   joinWith (' :: '),
-  replace (/->/g) ('-\u2060>'),
 ]);
 
 //    formatSignature :: Options -> String -> Number -> String -> String

--- a/scripts/test
+++ b/scripts/test
@@ -59,7 +59,7 @@ function identity(x) {
 exports.identity = identity;
 EOF
 IFS='' read -r -d '' expected <<'EOF'
-### <a name="identity" href="XXX">`identity :: a -⁠> a`</a>
+### <a name="identity" href="XXX">`identity :: a -> a`</a>
 
 The identity function. Returns its argument.
 


### PR DESCRIPTION
Closes #26

In addition to the copy–paste problem @kurtmilam reported in sanctuary-js/sanctuary#647, Safari does not render WORD JOINER correctly. Even though we are using the character for its intended purpose, the drawbacks outweigh the benefit.
